### PR TITLE
Add missing she-bang to start file

### DIFF
--- a/start
+++ b/start
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -euo pipefail
 
 mkdir -p $HOME/Desktop


### PR DESCRIPTION
According to the repo2docker docs, a `start` file must start with a she-bang

https://repo2docker.readthedocs.io/en/latest/config_files.html#start-run-code-before-the-user-sessions-starts

I'm not sure if this will solve your problem quite yet though. Let's see.