### PR TITLE
Stop using a fork of repo2docker-action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@main
 
     - name: Build and push the image to quay.io
-      uses: yuvipanda/repo2docker-action@extra-args
+      uses: jupyterhub/repo2docker-action@master
       with:
         # Make sure username & password/token pair matches your registry credentials
         DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
@@ -40,7 +40,6 @@ jobs:
         # Uncomment and modify the following line with your image name, otherwise no push will happen
         IMAGE_NAME: "volcanocyber/victor-notebook"
         REPO2DOCKER_EXTRA_ARGS: --Repo2Docker.base_image=docker.io/library/buildpack-deps:jammy
-        FORCE_REPO2DOCKER_VERSION: git+https://github.com/yuvipanda/repo2docker@feat/new-base
 
 
     # Lets us monitor disks getting full as images get bigger over time

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@main
 
     - name: Build the image and push it if `NO_PUSH` disabled
-      uses: yuvipanda/repo2docker-action@extra-args
+      uses: jupyterhub/repo2docker-action@master
       with: # make sure username & password/token matches your registry
         NO_PUSH: "true"
         DOCKER_REGISTRY: "quay.io"
@@ -35,7 +35,6 @@ jobs:
         # Uncomment and modify the following line with your image name.
         IMAGE_NAME: "volcanocyber/victor-notebook"
         REPO2DOCKER_EXTRA_ARGS: --Repo2Docker.base_image=docker.io/library/buildpack-deps:jammy
-        FORCE_REPO2DOCKER_VERSION: git+https://github.com/yuvipanda/repo2docker@feat/new-base
 
     # Lets us monitor disks getting full as images get bigger over time
     - name: Show how much disk space is left


### PR DESCRIPTION
A new release of repo2docker was just made with the base_image made configurable, so we don't need to use my fork anymore!