### PR TITLE
Use tightvncserver

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -29,3 +29,4 @@ ninja-build
 libasound2
 libdbus-glib-1-2
 libpci-dev
+tightvncserver

--- a/environment.yml
+++ b/environment.yml
@@ -84,7 +84,7 @@ dependencies:
     - cdsapi
     - utm
     - jupyterlab-s3-browser
-    - jupyter-desktop-server==0.1.3
+    - jupyter-remote-desktop-proxy
     - geojsoncontour
   - pop-tools
   - prefect=0.15.13
@@ -138,4 +138,3 @@ dependencies:
   - jedi-language-server
   - shapely
   - numexpr
-  - paraview


### PR DESCRIPTION
See https://github.com/2i2c-org/infrastructure/issues/2805

Also use jupyterhub/jupyter-remote-desktop-proxy

Remove paraview to try fix build