### PR TITLE
Appendix commands need to run as root

### DIFF
--- a/appendix
+++ b/appendix
@@ -1,9 +1,10 @@
 # COPY doesn't work as expected due to how repo2docker works.
 # repo2docker installs the repo to ${REPO_DIR}
+USER root
 RUN cp ${REPO_DIR}/mozilla-firefox.apt.preferences /etc/apt/preferences.d/mozilla-firefox
 RUN add-apt-repository ppa:mozillateam/ppa \
     && apt-get update -qq --yes \
     && apt-get install -qq --yes -t 'o=LP-PPA-mozillateam' --yes firefox \
     && rm -rf /var/lib/apt/lists/*
 
-
+USER $NB_USER


### PR DESCRIPTION
@volcanocyber please merge this, the way the appendix was wired in didn't match my expectation so I'm having to explicitly set the user and reset it at the end